### PR TITLE
Fix I2C blocking at least 1s if no response is captured

### DIFF
--- a/components/driver/i2c/i2c.c
+++ b/components/driver/i2c/i2c.c
@@ -1544,10 +1544,10 @@ esp_err_t i2c_master_cmd_begin(i2c_port_t i2c_num, i2c_cmd_handle_t cmd_handle, 
     while (1) {
         TickType_t wait_time = xTaskGetTickCount();
         if (wait_time - ticks_start > ticks_to_wait) { // out of time
-            wait_time = I2C_CMD_ALIVE_INTERVAL_TICK;
+            wait_time = 0;
         } else {
             wait_time = ticks_to_wait - (wait_time - ticks_start);
-            if (wait_time < I2C_CMD_ALIVE_INTERVAL_TICK) {
+            if (wait_time > I2C_CMD_ALIVE_INTERVAL_TICK) {
                 wait_time = I2C_CMD_ALIVE_INTERVAL_TICK;
             }
         }


### PR DESCRIPTION
## Info
Fixes I2C Problems. See commit.